### PR TITLE
Support `remote_api` worker backend and environment configuration

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -24,12 +24,19 @@ server:
 # Worker configuration
 worker:
   server_url: "http://127.0.0.1:8099"
-  backend: "dummy"  # Options: "dummy", "qwen3vl"
+  backend: "dummy"  # Options: "dummy", "qwen3vl", "remote_api"
   
   # Qwen3VL-specific settings (only used when backend: qwen3vl)
   qwen3vl:
     model_path: "/path/to/Qwen3-VL-32B-Instruct"  # Or HuggingFace model name
     device_map: "balanced"  # "auto", "balanced", "balanced_low_0", or specific device
+
+  # Remote API settings (only used when backend: remote_api)
+  remote_api:
+    api_url: "http://127.0.0.1:8080/infer"
+    api_key: ""
+    timeout_sec: 60.0
+    headers: {}
 
 # Windowing configuration
 windowing:

--- a/src/video2tasks/server/app.py
+++ b/src/video2tasks/server/app.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import uvicorn
 
 from ..config import Config, DatasetConfig
@@ -24,9 +24,9 @@ class SubmitModel(BaseModel):
     """Model for job result submission."""
     task_id: str
     vlm_output: str = ""
-    vlm_json: Dict[str, Any] = {}
+    vlm_json: Dict[str, Any] = Field(default_factory=dict)
     latency_s: float = 0.0
-    meta: Dict[str, Any] = {}
+    meta: Dict[str, Any] = Field(default_factory=dict)
 
 
 @dataclass

--- a/src/video2tasks/worker/runner.py
+++ b/src/video2tasks/worker/runner.py
@@ -39,7 +39,14 @@ def run_worker(config: Config) -> None:
     if config.worker.backend == "qwen3vl":
         backend_kwargs = {
             "model_path": config.worker.qwen3vl.model_path,
-            "device_map": config.worker.qwen3vl.device_map
+            "device_map": config.worker.qwen3vl.device_map,
+        }
+    elif config.worker.backend == "remote_api":
+        backend_kwargs = {
+            "url": config.worker.remote_api.api_url,
+            "api_key": config.worker.remote_api.api_key,
+            "headers": config.worker.remote_api.headers,
+            "timeout_sec": config.worker.remote_api.timeout_sec,
         }
     
     backend = create_backend(config.worker.backend, **backend_kwargs)


### PR DESCRIPTION
### Motivation
- Enable using a remote HTTP VLM inference backend (`remote_api`) from workers and make it configurable via file or environment variables.
- Surface remote API connection options (URL, API key, timeout, headers) so workers can be pointed at external inference services.
- Prevent accidental shared mutable state in server request models by avoiding plain mutable default dicts.

### Description
- Add `RemoteAPIConfig` model and a `remote_api` field to `WorkerConfig`, and extend backend validation to accept `"remote_api"` in `src/video2tasks/config.py`.
- Add environment-variable overrides for `REMOTE_API_URL`, `REMOTE_API_KEY`, `REMOTE_API_TIMEOUT`, and `REMOTE_API_HEADERS` (the latter parsed as JSON with validation) in `Config.from_env`.
- Document `remote_api` settings in `config.example.yaml` with `api_url`, `api_key`, `timeout_sec`, and `headers` entries.
- Wire `remote_api` settings into worker initialization in `src/video2tasks/worker/runner.py` so `create_backend` receives `url`, `api_key`, `headers`, and `timeout_sec` when `config.worker.backend == "remote_api"`.
- Replace mutable default dicts in `SubmitModel` by using `Field(default_factory=dict)` for `vlm_json` and `meta` in `src/video2tasks/server/app.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ef815a63483308a87a0a97dec0157)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new HTTP-driven inference path and new env-based configuration parsing (including JSON header parsing), which can affect worker reliability and runtime behavior if misconfigured.
> 
> **Overview**
> Adds support for a `remote_api` worker backend, including YAML and environment-variable configuration for API URL/key/timeout/extra headers (JSON-parsed), and wires these options into worker backend initialization.
> 
> Updates the server’s `SubmitModel` to avoid shared mutable default dicts via `Field(default_factory=dict)`, and documents the new backend settings in `config.example.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40e8dd058ed69b60e948cbd8990eb607b7de4355. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->